### PR TITLE
decoder modifications

### DIFF
--- a/lib/opus-ruby.rb
+++ b/lib/opus-ruby.rb
@@ -25,7 +25,7 @@ module Opus
     OPUS_SET_BITRATE_REQUEST              = 4002
     OPUS_SET_VBR_REQUEST                  = 4006
     OPUS_RESET_STATE                      = 4028
-  end
+  end 
 
   attach_function :opus_encoder_get_size, [:int], :int
   attach_function :opus_encoder_create, [:int32, :int, :int, :pointer], :pointer
@@ -42,4 +42,5 @@ module Opus
   attach_function :opus_decode_float, [:pointer, :pointer, :int32, :pointer, :int, :int], :int
   attach_function :opus_decoder_ctl, [:pointer, :int, :varargs], :int
   attach_function :opus_decoder_destroy, [:pointer], :void
+  attach_function :opus_packet_get_samples_per_frame, [:pointer, :int32], :int
 end

--- a/lib/opus-ruby/decoder.rb
+++ b/lib/opus-ruby/decoder.rb
@@ -57,7 +57,7 @@ module Opus
 			#@frame_size = Opus.opus_packet_get_samples_per_frame packet, @sample_rate
 			#max_size = @frame_size * @channels
 			# since calculation runs wrong, set it to max. framesize that should occur.
-			max_size = 2880
+			max_size = 5760 #2880
 			decoded = FFI::MemoryPointer.new :short, max_size + 1
 
 			frame_size = Opus.opus_decode @decoder, packet, len, decoded, max_size, 0
@@ -66,6 +66,10 @@ module Opus
 				frame_size = 0
 			end
 			return decoded.read_string_length frame_size * 2
+		end
+		
+		def decode_missed
+			Opus.opus_decode @decoder, nil, 0, nil, 0, 0
 		end
 
 		def get_lasterror_code

--- a/lib/opus-ruby/decoder.rb
+++ b/lib/opus-ruby/decoder.rb
@@ -62,6 +62,7 @@ module Opus
 
 			frame_size = Opus.opus_decode @decoder, packet, len, decoded, max_size, 0
 			if frame_size < 0 then
+				@lasterror = frame_size
 				frame_size = 0
 			end
 			return decoded.read_string_length frame_size * 2

--- a/lib/opus-ruby/decoder.rb
+++ b/lib/opus-ruby/decoder.rb
@@ -27,72 +27,64 @@
 
 
 module Opus
-	class Decoder
-		attr_reader :sample_rate, :frame_size, :channels
+    class Decoder
+        attr_reader :sample_rate, :frame_size, :channels
 
-		def initialize( sample_rate, frame_size, channels)
-			@sample_rate = sample_rate
-			@frame_size = frame_size
-			@channels = channels
-			@lasterror = 0
+        def initialize( sample_rate, frame_size, channels)
+            @sample_rate = sample_rate
+            @frame_size = frame_size
+            @channels = channels
+            @lasterror = 0
 
-			@decoder = Opus.opus_decoder_create sample_rate, channels, nil
-		end
+            @decoder = Opus.opus_decoder_create sample_rate, channels, nil
+        end
 
-		def destroy
-			Opus.opus_decoder_destroy @decoder
-		end
+        def destroy
+            Opus.opus_decoder_destroy @decoder
+        end
 
-		def reset
-			Opus.opus_decoder_ctl @decoder, Opus::Constants::OPUS_RESET_STATE, :pointer, nil
-		end
+        def reset
+            Opus.opus_decoder_ctl @decoder, Opus::Constants::OPUS_RESET_STATE, :pointer, nil
+        end
 
-		def decode( data )
-			len = data.size
+        def decode( data )
+            len = data.size
 
-			packet = FFI::MemoryPointer.new :char, len + 1
-			packet.put_string 0, data
+            packet = FFI::MemoryPointer.new :char, len + 1
+            packet.put_string 0, data
 
-			# Always get correct frame_size, @sample_rate has to be the right value, else we get wrong size! 
-			#@frame_size = Opus.opus_packet_get_samples_per_frame packet, @sample_rate
-			#max_size = @frame_size * @channels
-			# since calculation runs wrong, set it to max. framesize that should occur.
-			max_size = 5760 #2880
-			decoded = FFI::MemoryPointer.new :short, max_size + 1
+            max_size = @frame_size * @channels * 2 # Was getting buffer_too_small errors without the 2
+            decoded = FFI::MemoryPointer.new :short, max_size + 1
 
-			frame_size = Opus.opus_decode @decoder, packet, len, decoded, max_size, 0
-			if frame_size < 0 then
-				@lasterror = frame_size
-				frame_size = 0
-			end
-			return decoded.read_string_length frame_size * 2
-		end
-		
-		def decode_missed
-			Opus.opus_decode @decoder, nil, 0, nil, 0, 0
-		end
+            frame_size = Opus.opus_decode @decoder, packet, len, decoded, max_size, 0
+            if frame_size < 0 then
+                @lasterror = frame_size
+                frame_size = 0
+            end
+            return decoded.read_string_length frame_size * 2
+        end
 
-		def get_lasterror_code
-			return @lasterror
-		end
+        def decode_missed
+            Opus.opus_decode @decoder, nil, 0, nil, 0, 0
+        end
 
-		def get_lasterror_string
-			errorstring = case @lasterror
-				when 0 then "OK"
-				when -1 then "BAD ARG"
-				when -2 then "BUFFER TOO SMALL"
-				when -3 then "INTERNAL ERROR"
-				when -4	then "INVALID PACKET"
-				when -5 then "UNIMPLEMENTED"
-				when -6 then "INVALID STATE"
-				when -7	then "ALLOC FAIL"
-				else "UNKNOWN ERROR / ERROR NOT DEFINED (should never happen)"
-			return errorstring
-			end
-		end
+        def get_lasterror_code
+            return @lasterror
+        end
 
-
-	end
+        def get_lasterror_string
+            errorstring = case @lasterror
+                when 0 then "OK"
+                when -1 then "BAD ARG"
+                when -2 then "BUFFER TOO SMALL"
+                when -3 then "INTERNAL ERROR"
+                when -4	then "INVALID PACKET"
+                when -5 then "UNIMPLEMENTED"
+                when -6 then "INVALID STATE"
+                when -7	then "ALLOC FAIL"
+                else "UNKNOWN ERROR / ERROR NOT DEFINED (should never happen)"
+            return errorstring
+            end
+        end
+    end
 end
-
-


### PR DESCRIPTION
function for frame size calculation does not give me right size. I think it is because of false using. Commented it out and set frame-buffer to highest value I seen it in my mumble-ruby project.
Add ability to query last error occured while try decoding.
